### PR TITLE
Correct itemByStack(), fixes #10 and #36

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 /.classpath
 /.project
 /.settings
+/bin/

--- a/src/main/java/net/milkbowl/vault/item/Items.java
+++ b/src/main/java/net/milkbowl/vault/item/Items.java
@@ -817,10 +817,16 @@ public class Items {
         }
 
         for (ItemInfo item : items) {
-            if (itemStack.getType().equals(item.getType()) && item.isDurable()) {
-                return item;
-            } else if (itemStack.getType().equals(item.getType()) && item.getSubTypeId() == itemStack.getDurability()) {
-                return item;
+            if (itemStack.getType().equals(item.getType())) {
+                if (itemStack.getType().isSolid() && item.getType().isSolid()) {
+                    //Solid, so check durability (Podzol, Colored Wool, et al.)
+                    if (item.isDurable()) {
+                        return item;
+                    }
+                } else {
+                    //Not solid, so ignore durability (Stick, Stone Button, et al.)
+                    return item;
+                }
             }
         }
 


### PR DESCRIPTION
Previously, checking durability via isDurable() for all ItemStacks caused materials without collision, like Buttons, to return as null. Now, durability is only checked if the ItemStack equates to a solid block (to account for variations like Smooth Brick and Red Wool).