### PR TITLE
Fix NullPointerException

### DIFF
--- a/src/main/java/net/milkbowl/vault/item/Items.java
+++ b/src/main/java/net/milkbowl/vault/item/Items.java
@@ -27,7 +27,7 @@ import org.bukkit.inventory.ItemStack;
 
 public class Items {
 
-    private static final List<ItemInfo> items = new CopyOnWriteArrayList<ItemInfo>();
+    private static final List<ItemInfo> items = new CopyOnWriteArrayList<>();
 
     /**
      * Returns the list of ItemInfo's registered in Vault as an UnmodifiableList.


### PR DESCRIPTION
### **Please read it first!**

If you accept this, you can fix a lot of mistakes. This NullPointerException occurs when a user uses Java 8 (the latest) or 9 versions. I've experienced this and many more plugins for many users, but I've been there too.
Plus that can be good for code cleaning. :)