### PR TITLE
Removed type jar and replaced it with scope provided

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>net.milkbowl.vault</groupId>
 	<artifactId>VaultAPI</artifactId>
-	<version>1.7</version>
+	<version>1.7.1</version>
 
 	<name>VaultAPI</name>
 	<description>Vault is a Permissions &amp; Economy API to allow plugins to more easily hook into these systems without needing to hook each individual system themselves.
@@ -59,7 +59,7 @@ Vault currently supports the following: Permissions 3, PEX, GroupManager, bPerms
 			<groupId>org.bukkit</groupId>
 			<artifactId>bukkit</artifactId>
 			<version>${bukkitVersion}</version>
-			<type>jar</type>
+			<scope>provided</scope>
 		</dependency>
 		<!-- Test Dependency -->
 		<dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>net.milkbowl.vault</groupId>
 	<artifactId>VaultAPI</artifactId>
-	<version>1.7.1</version>
+	<version>1.7</version>
 
 	<name>VaultAPI</name>
 	<description>Vault is a Permissions &amp; Economy API to allow plugins to more easily hook into these systems without needing to hook each individual system themselves.


### PR DESCRIPTION
This will remove the presence of Bukkit while resolving VaultAPI.


Libraries resolving before fix.
![Screenshot 2019-12-14 at 02 12 37](https://user-images.githubusercontent.com/1420893/70841049-67a26b00-1e17-11ea-8472-5c3b6f59817a.png)

Libraries resolving after fix. 
![Screenshot 2019-12-14 at 02 12 58](https://user-images.githubusercontent.com/1420893/70841048-6709d480-1e17-11ea-9337-6a0c4cddf6cb.png)


@Sleaker I hope you're understanding it now. The problem before was that your reference to BukkitI is used in some project instead of using e.g Spigot-API 1.14.x. So all new features present in 1.14.x were not accessible.

So features like Player#spigot()... aren't accessible without explicitly excluding the version provided by Vault-API. This thread is an example for this: https://www.spigotmc.org/threads/player-spigot-does-not-exist.406974/#post-3621773

That are around 4 dependencies that we don't need when using Vault-API because they are provided at runtime by Spigot or CraftBukkit.