### PR TITLE
Add another Abstract Economy that doesn't support banks

### DIFF
--- a/src/main/java/net/milkbowl/vault/economy/NoBankSupportAbstractEconomy.java
+++ b/src/main/java/net/milkbowl/vault/economy/NoBankSupportAbstractEconomy.java
@@ -1,0 +1,74 @@
+package net.milkbowl.vault.economy;
+
+import java.util.List;
+import java.util.Collections;
+
+/**
+* Abstract class that removes the responsibility of implement
+* Bank methods for child classes that doesn't support banks
+*/
+public abstract class NoBankSupportEconomy extends AbstractEconomy {
+
+    // EconomyResponse class is immutable, it doesn't require the creation
+    // of more objects to return the same response
+    private final EconomyResponse response;
+
+    public NoBankSupportEconomy(String unsupportedMessage) {
+        this.response = new EconomyResponse(0, 0, EconomyResponse.ResponseType.NOT_IMPLEMENTED, unsupportedMessage);
+    }
+
+    public NoBankSupportEconomy() {
+        this("This economy manager doesn't support banks!");
+    }
+
+    @Override
+    public boolean hasBankSupport() {
+        return false;
+    }
+
+    @Override
+    public EconomyResponse createBank(String name, String playerName) {
+        return response;
+    }
+
+    @Override
+    public EconomyResponse deleteBank(String name) {
+        return response;
+    }
+
+    @Override
+    public EconomyResponse bankBalance(String name) {
+        return response;
+    }
+
+    @Override
+    public EconomyResponse bankHas(String name, double amount) {
+        return response;
+    }
+
+    @Override
+    public EconomyResponse bankWithdraw(String name, double amount) {
+        return response;
+    }
+
+    @Override
+    public EconomyResponse bankDeposit(String name, double amount) {
+        return response;
+    }
+
+    @Override
+    public EconomyResponse isBankOwner(String name, String playerName) {
+        return response;
+    }
+
+    @Override
+    public EconomyResponse isBankMember(String name, String playerName) {
+        return response;
+    }
+
+    @Override
+    public List<String> getBanks() {
+        return Collections.emptyList();
+    }
+
+}

--- a/src/main/java/net/milkbowl/vault/economy/NoBankSupportAbstractEconomy.java
+++ b/src/main/java/net/milkbowl/vault/economy/NoBankSupportAbstractEconomy.java
@@ -7,7 +7,7 @@ import java.util.Collections;
 * Abstract class that removes the responsibility of implement
 * Bank methods for child classes that doesn't support banks
 */
-public abstract class NoBankSupportEconomy extends AbstractEconomy {
+public abstract class NoBankSupportAbstractEconomy extends AbstractEconomy {
 
     // EconomyResponse class is immutable, it doesn't require the creation
     // of more objects to return the same response

--- a/src/main/java/net/milkbowl/vault/economy/NoBankSupportAbstractEconomy.java
+++ b/src/main/java/net/milkbowl/vault/economy/NoBankSupportAbstractEconomy.java
@@ -13,11 +13,11 @@ public abstract class NoBankSupportAbstractEconomy extends AbstractEconomy {
     // of more objects to return the same response
     private final EconomyResponse response;
 
-    public NoBankSupportEconomy(String unsupportedMessage) {
+    public NoBankSupportAbstractEconomy(String unsupportedMessage) {
         this.response = new EconomyResponse(0, 0, EconomyResponse.ResponseType.NOT_IMPLEMENTED, unsupportedMessage);
     }
 
-    public NoBankSupportEconomy() {
+    public NoBankSupportAbstractEconomy() {
         this("This economy manager doesn't support banks!");
     }
 


### PR DESCRIPTION
Add another abstract class to make it easier for developers to decide whether to implement bank support or not. If they decide not to, they will simply extend this class and not have to implement each of the bank related methods and always return "NOT_IMPLEMENTED"