### PR TITLE
Removed not needed space

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ public class ExamplePlugin extends JavaPlugin {
 
     @Override
     public void onEnable() {
-        if (!setupEconomy() ) {
+        if (!setupEconomy()) {
             log.severe(String.format("[%s] - Disabled due to no Vault dependency found!", getDescription().getName()));
             getServer().getPluginManager().disablePlugin(this);
             return;


### PR DESCRIPTION
There is a typo in the readme at line 97
```java
        if (!setupEconomy() ) {
```
This PR just changes that to 
```java
        if (!setupEconomy()) {
```